### PR TITLE
Set InternalIP for only primary network

### DIFF
--- a/pkg/ccm/vminfocache.go
+++ b/pkg/ccm/vminfocache.go
@@ -67,11 +67,14 @@ func (vmic *VmInfoCache) vmToVMInfo(vm *govcd.VM, captureTime time.Time) (*VmInf
 	if vm.VM.NetworkConnectionSection != nil {
 		vmAddresses := make([]v1.NodeAddress, 0)
 		for _, netConn := range vm.VM.NetworkConnectionSection.NetworkConnection {
+			if netConn.NetworkConnectionIndex == vm.VM.NetworkConnectionSection.PrimaryNetworkConnectionIndex {
+				v1helper.AddToNodeAddresses(&vmAddresses,
+					v1.NodeAddress{
+						Type:    v1.NodeInternalIP,
+						Address: netConn.IPAddress,
+					})
+			}
 			v1helper.AddToNodeAddresses(&vmAddresses,
-				v1.NodeAddress{
-					Type:    v1.NodeInternalIP,
-					Address: netConn.IPAddress,
-				},
 				v1.NodeAddress{
 					Type:    v1.NodeExternalIP,
 					Address: netConn.IPAddress,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25903

When there are multiple NICs on machines, all IPs of machines are added as `InternalIP`. 

```
status:
  addresses:
  - address: 10.6.1.2
    type: InternalIP
  - address: 10.12.3.4
    type: InternalIP
  - address: 10.6.1.2
    type: ExternalIP
  - address: 10.12.3.4
    type: ExternalIP
  - address: myhostname
    type: Hostname
```

This is a valid case when the user sets `ExtraOvdcNetworks`  in `VCDMachine`. See 
https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/api/v1beta1/vcdmachine_types.go#L79

However, only IPs of primary network should be `InternalIP`. There is no guarantee that nodes can access other nodes via extra NICs. 
See https://github.com/vmware/cloud-provider-for-cloud-director/blob/main/vendor/k8s.io/api/core/v1/types.go#L4946

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cloud-provider-for-cloud-director/225)
<!-- Reviewable:end -->
